### PR TITLE
Fix obstacle-tower-env to v1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+git://github.com/Unity-Technologies/obstacle-tower-env@master
+git+git://github.com/Unity-Technologies/obstacle-tower-env@v1.1
 aicrowd-repo2docker


### PR DESCRIPTION
One thing that we may want to do is add `obstacle-tower-env` to PyPI as well.